### PR TITLE
ADD BASELINE option and reset PT24H

### DIFF
--- a/ioda_mods_hera
+++ b/ioda_mods_hera
@@ -1,0 +1,17 @@
+# environment for JEDI IODA, from Henry. 
+
+module purge 
+unset LD_LIBRARY_PATH
+unset PYTHONPATH
+
+export UFSRNR_STACK=/scratch2/BMC/gsienkf/UFS-RNR/UFS-RNR-stack
+export JEDI_OPT=/scratch1/NCEPDEV/jcsda/jedipara/opt/modules
+module use $JEDI_OPT/modulefiles/core
+module load jedi/intel-impi/2020.2
+
+export JEDI_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
+module use -a ${UFSRNR_STACK}/modules
+# this clashes with fv3-jedi. Can't use single environment for both.
+module load anaconda3
+export LD_LIBRARY_PATH=${UFSRNR_STACK}/external/ioda-bundle/build/lib:$JEDI_LD_LIBRARY_PATH
+export PYTHONPATH=${UFSRNR_STACK}/external/ioda-bundle/build/lib/pyiodaconv:${UFSRNR_STACK}/external/ioda-bundle/build/lib/python3.9/pyioda

--- a/jedi/fv3-jedi/yaml_files/20220921/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/20220921/letkfoi_snow.yaml
@@ -17,7 +17,7 @@ geometry:
     filename_orog: XXTSTUB.nc
 
 window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
-window length: PT6H
+window length: PT24H
 
 background:
  date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z

--- a/jedi/fv3-jedi/yaml_files/release-v1.0/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/release-v1.0/letkfoi_snow.yaml
@@ -18,7 +18,7 @@ geometry:
 
 
 window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
-window length: PT6H
+window length: PT24H
 
 background:
  date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z

--- a/jedi_mods_ioda
+++ b/jedi_mods_ioda
@@ -1,0 +1,21 @@
+
+module purge
+
+######################################
+# JEDI FV3-bundle mods 
+setenv JEDI_OPT /scratch1/NCEPDEV/jcsda/jedipara/opt/modules
+module use $JEDI_OPT/modulefiles/core
+
+module load jedi/intel-impi/2020.2
+
+#  additional, needed for JEDI IODA converter 
+module load intelpython/3.6.8 
+
+setenv SLURM_ACCOUNT gsienkf
+setenv SALLOC_ACCOUNT $SLURM_ACCOUNT
+setenv SBATCH_ACCOUNT $SLURM_ACCOUNT
+
+######################################
+
+# needed for add_jedi_incr
+module load netcdf

--- a/land_mods_hera
+++ b/land_mods_hera
@@ -1,0 +1,5 @@
+
+module purge
+module load  intel/2020.2
+module load impi/2018.0.4
+module load  netcdf/4.7.0


### PR DESCRIPTION
- This PR is to set da window PT24H and add BASELINE option for hera.internal test.
- In case of hera.internal, pre-built fv3 and ioda bundles are loaded.