### PR TITLE
Update to the latest JEDI version for new 'hera_internal' baseline 

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -13,4 +13,4 @@ done
 # create links 
 echo 'creating jedi links'
 cd jedi/fv3-jedi/Data/
-make_links.sh
+./make_links.sh

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -27,12 +27,8 @@ fi
 echo "reading DA settings from $config_file"
 
 GFSv17=${GFSv17:-"NO"}
+fv3bundle_vn=${fv3bundle_vn:-"psl_develop"}
 
-if [[ ${BASELINE} =~ 'hera.internal' ]]; then
-  fv3bundle_vn=${fv3bundle_vn:-"psl_develop"}
-else
-  fv3bundle_vn=${fv3bundle_vn:-"release-v1.0"} #need debugging ${fv3bundle_vn:-"release-v1.0"}
-fi
 source $config_file
 
 LOGDIR=${OUTDIR}/DA/logs/
@@ -316,14 +312,13 @@ if [[ ! -e Data ]]; then
 fi
 
 echo 'do_landDA: calling fv3-jedi'
-if [[ ${BASELINE} =~ 'hera.internal' ]]; then 
-  source ${JEDI_EXECDIR}/../../../fv3_mods_hera
-fi
+
 if [[ $do_DA == "YES" ]]; then
     if [[ ${BASELINE} =~ 'hera.internal' ]]; then
+    source ${JEDI_EXECDIR}/../../../fv3_mods_hera
     srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
     else
-    ${MPIEXEC} -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
+    srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
     fi
     if [[ $? != 0 ]]; then
         echo "JEDI DA failed"
@@ -332,9 +327,10 @@ if [[ $do_DA == "YES" ]]; then
 fi 
 if [[ $do_HOFX == "YES" ]]; then
     if [[ ${BASELINE} =~ 'hera.internal' ]]; then
+    source ${JEDI_EXECDIR}/../../../fv3_mods_hera
     srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
     else  
-    ${MPIEXEC} -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
+    srun -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
     fi
     if [[ $? != 0 ]]; then
         echo "JEDI hofx failed"

--- a/ioda_mods_hera
+++ b/ioda_mods_hera
@@ -1,17 +1,30 @@
-# environment for JEDI IODA, from Henry. 
+module purge
+ module use /scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles
+ export UFSRNR_STACK=/scratch2/BMC/gsienkf/UFS-RNR/UFS-RNR-stack
+ module use -a ${UFSRNR_STACK}/modules
+ module load anaconda3
+ pythondir=/scratch2/BMC/gsienkf/UFS-RNR/UFS-RNR-stack/anaconda3
+#module load miniconda/3.9.12
+ module load ecflow/5.5.3
+ module use /scratch1/NCEPDEV/global/spack-stack/spack-stack-v1/envs/skylab-3.0.0-intel-2021.5.0/install/modulefiles/Core
+ module load stack-intel/2021.5.0
+ module load stack-intel-oneapi-mpi/2021.5.1
+#module load stack-python/3.9.12
+#module available
+ module load jedi-fv3-env/1.0.0
+ module load jedi-ewok-env/1.0.0
+#module load soca-env/1.0.0
+ export PROJ_LIB=${pythondir}/share/proj
+ export PYTHONPATH=${pythondir}/lib
+ export LD_LIBRARY_PATH=${pythondir}/lib:${LD_LIBRARY_PATH}
+ export PATH=${pythondir}/bin:${PATH}
 
-module purge 
-unset LD_LIBRARY_PATH
-unset PYTHONPATH
+#ioda-bundle build dir:
+ export iodablddir=/scratch2/NCEPDEV/land/data/jedi/ioda-bundle/build
+ export LD_LIBRARY_PATH=${iodablddir}/lib:$LD_LIBRARY_PATH
 
-export UFSRNR_STACK=/scratch2/BMC/gsienkf/UFS-RNR/UFS-RNR-stack
-export JEDI_OPT=/scratch1/NCEPDEV/jcsda/jedipara/opt/modules
-module use $JEDI_OPT/modulefiles/core
-module load jedi/intel-impi/2020.2
+ export PYTHONPATH=$PYTHONPATH:/scratch2/NCEPDEV/land/data/jedi/ioda-bundle/src/iodaconv/src
+ export PYTHONPATH=${iodablddir}/lib/pyiodaconv:$PYTHONPATH
+ export PYTHONPATH=${iodablddir}/lib/python3.9/pyioda:$PYTHONPATH
 
-export JEDI_LD_LIBRARY_PATH=$LD_LIBRARY_PATH
-module use -a ${UFSRNR_STACK}/modules
-# this clashes with fv3-jedi. Can't use single environment for both.
-module load anaconda3
-export LD_LIBRARY_PATH=${UFSRNR_STACK}/external/ioda-bundle/build/lib:$JEDI_LD_LIBRARY_PATH
-export PYTHONPATH=${UFSRNR_STACK}/external/ioda-bundle/build/lib/pyiodaconv:${UFSRNR_STACK}/external/ioda-bundle/build/lib/python3.9/pyioda
+

--- a/jedi/fv3-jedi/yaml_files/psl_develop/C768.letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/C768.letkfoi_snow.yaml
@@ -1,0 +1,60 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  layout: [3,4]
+  io_layout: [1,1]
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+
+  time invariant fields:
+    state fields:
+      datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+      filetype: fms restart
+      skip coupler file: true
+      state variables: [orog_filt]
+      datapath: XXTPATH
+      filename_orog: XXTSTUB.nc
+    derived fields: [nominal_surface_pressure]
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT24H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/jedi/fv3-jedi/yaml_files/psl_develop/GHCN.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/GHCN.yaml
@@ -1,0 +1,59 @@
+  - obs space:
+      name: SnowDepthGHCN
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GHCN_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ghcn_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: MetaData/height
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    # GFSv17 only.
+    #- filter: Domain Check # no sea ice
+    #  where:
+    #  - variable:
+    #      name: GeoVaLs/fraction_of_ice
+    #    maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/GTS.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/GTS.yaml
@@ -1,0 +1,96 @@
+  - obs space:
+      name: SnowDepthGTS
+      distribution:
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GTS_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_gts_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Composite
+      components:
+      # operator used to evaluate H(x)
+      - name: Identity
+      # operator used to evaluate background errors
+      - name: BackgroundErrorIdentity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+      maxvalue: 2000.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: MetaData/height
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: BlackList
+      where:
+      - variable:
+          name: MetaData/station_id
+        is_in: [71120,71397,71621,71727,71816]
+        size where true: 5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+    - filter: Met Office Buddy Check
+      filter variables:
+      - name: totalSnowDepth
+      rejection_threshold: 0.5
+      traced_boxes: # trace all observations
+        - min_latitude: -90
+          max_latitude:  90
+          min_longitude: -180
+          max_longitude:  180
+      search_radius: 150 # km
+      station_id_variable:
+        name: MetaData/station_id
+      num_zonal_bands: 24
+      sort_by_pressure: false
+      max_total_num_buddies: 15
+      max_num_buddies_from_single_band: 10
+      max_num_buddies_with_same_station_id: 5
+      use_legacy_buddy_collector: false
+      horizontal_correlation_scale: { "-90": 150, "90": 150 }
+      temporal_correlation_scale: PT6H
+      damping_factor_1: 1.0
+      damping_factor_2: 1.0
+      background_error_group: BkgError
+    - filter: Variable Assignment
+      assignments:
+      - name: GrossErrorProbability/totalSnowDepth
+        type: float
+        value: 0.02
+      - name: BkgError/totalSnowDepth_background_error
+        type: float
+        value: 30.0

--- a/jedi/fv3-jedi/yaml_files/psl_develop/IMS.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/IMS.yaml
@@ -1,0 +1,47 @@
+  - obs space:
+      name: SnowDepthIMS
+      distribution:
+         name: Halo
+         halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      observed variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: ioda.IMSscf.XXYYYYXXMMXXDD.XXTSTUB.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ims_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 1
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/SMAP.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/SMAP.yaml
@@ -1,0 +1,45 @@
+  - obs space:
+      name: SoilMoistureSMAP
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [soilMoistureVolumetric]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: SMAP_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_smap_XXYYYYXXMMXXDDTXXHH00.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+    obs filters:
+    - filter: Domain Check
+      where:
+      - variable: # land only
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check
+      where:
+      - variable: # no snow
+          name: GeoVaLs/sheleg
+        maxvalue: 0.0
+    - filter: Domain Check
+      where:
+      - variable: # high-quality retrievals
+          name: PreQC/soilMoistureVolumetric
+        is_in: 0, 8
+    - filter: BlackList 
+      where:
+      - variable: # exclude certain IGBP vegetation types
+          name: GeoVaLs/vtype
+        absolute_tolerance: 1.0e-3
+        is_close_to_any_of: [1, 2, 3, 4, 13, 15, 17]

--- a/jedi/fv3-jedi/yaml_files/psl_develop/gfs-land-v17.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/gfs-land-v17.yaml
@@ -1,0 +1,16 @@
+field metadata:
+
+- long name: slmsk
+  interpolation type: nearest
+
+- long name: totalSnowDepth
+  io name: snodl
+  interpolation type: nearest
+
+- long name: vtype
+  interpolation type: nearest
+
+- long name: fraction_of_ice
+  io name: fice
+  interpolation type: nearest
+

--- a/jedi/fv3-jedi/yaml_files/psl_develop/gfs-soilMoisture.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/gfs-soilMoisture.yaml
@@ -1,0 +1,22 @@
+field metadata:
+
+- long name: slmsk
+  interpolation type: nearest
+
+- long name: vtype
+  interpolation type: nearest
+
+- long name: sheleg
+  interpolation type: nearest
+
+#- long name: tgxy
+#  io name: tgxy
+#  interpolation type: nearest
+
+- long name: stc
+  interpolation type: nearest
+  io file: surface
+
+- long name: soilMoistureVolumetric
+  io name: smc
+  io file: surface

--- a/jedi/fv3-jedi/yaml_files/psl_develop/letkf_snow.yaml_jedi_testcase
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/letkf_snow.yaml_jedi_testcase
@@ -1,0 +1,115 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk127.nc4
+  npx: 49
+  npy: 49
+  npz: 127
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+  time invariant state fields:
+    datetime: 2019-12-15T18:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: Data/inputs/gfs_land_c48/grid/
+    filename_orog: C48_oro_data.nc
+
+window begin: 2019-12-15T15:00:00Z
+window length: PT6H
+
+background:
+ date: &date 2019-12-15T18:00:00Z
+ members:
+   - datetime: 2019-12-15T18:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: Data/inputs/gfs_land_c48/mem001/
+     filename_sfcd: 20191215.180000.sfc_data.nc
+     filename_cplr: 20191215.180000.coupler.res
+   - datetime: 2019-12-15T18:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: Data/inputs/gfs_land_c48/mem002/
+     filename_sfcd: 20191215.180000.sfc_data.nc
+     filename_cplr: 20191215.180000.coupler.res
+
+observations:
+  observers:
+  - obs space:
+      name: Simulate
+      distribution:
+        name: InefficientDistribution
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: Data/obs/testinput_tier_1/ghcn_snwd_ioda_20191215.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: height@MetaData
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+
+driver:
+  save posterior mean: true
+  save posterior mean increment: true
+  save posterior ensemble: false
+ # update obs config is set to true by default (which also implies halo distribution is used)
+ # need set to false here because halo distribution is NOT used for this run
+  update obs config with geometry info: false
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output:
+  filetype: auxgrid
+  gridtype: latlon
+  filename: Data/analysis/letkf/gfs_land/mem%{member}%/letkf.
+
+output increment:
+  filetype: auxgrid
+  gridtype: latlon
+  filename: Data/analysis/letkf/gfs_land/mem%{member}%/xainc.
+
+test:
+  reference filename: testoutput/letkf_snow.ref
+  test output filename: testoutput/letkf_snow.test.out

--- a/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_replay_GFSv17.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_replay_GFSv17.yaml
@@ -1,0 +1,166 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: gfs-land-v17.yaml
+
+  time invariant state fields:
+    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: XXTPATH
+    filename_orog: XXTSTUB.nc
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT6H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk,fice]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk,fice]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:
+  - obs space:
+      name: SnowDepthIMS
+      distribution:
+         name: Halo
+         halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      observed variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: ioda.IMSscf.XXYYYYXXMMXXDD.XXTSTUB.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ims_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 1
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: fraction_of_ice@GeoVaLs
+        maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+  - obs space:
+      name: Simulate
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GHCN_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ghcn_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: height@MetaData
+        minvalue: -999.0
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: fraction_of_ice@GeoVaLs
+        maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_smc.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_smc.yaml
@@ -1,0 +1,50 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: gfs-soilMoisture.yaml
+
+  time invariant state fields:
+    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: XXTPATH
+    filename_orog: XXTSTUB.nc
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT6H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [smc, vtype, sheleg, slmsk, stc]
+     datapath: ./
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/letkfoi_snow.yaml
@@ -1,0 +1,58 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+
+  time invariant fields:
+    state fields:
+      datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+      filetype: fms restart
+      skip coupler file: true
+      state variables: [orog_filt]
+      datapath: XXTPATH
+      filename_orog: XXTSTUB.nc
+    derived fields: [nominal_surface_pressure]
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT24H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/C768.letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/C768.letkfoi_snow.yaml
@@ -1,0 +1,60 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  layout: [3,4]
+  io_layout: [1,1]
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+
+  time invariant fields:
+    state fields:
+      datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+      filetype: fms restart
+      skip coupler file: true
+      state variables: [orog_filt]
+      datapath: XXTPATH
+      filename_orog: XXTSTUB.nc
+    derived fields: [nominal_surface_pressure]
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT24H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/GHCN.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/GHCN.yaml
@@ -1,0 +1,59 @@
+  - obs space:
+      name: SnowDepthGHCN
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GHCN_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ghcn_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: MetaData/height
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    # GFSv17 only.
+    #- filter: Domain Check # no sea ice
+    #  where:
+    #  - variable:
+    #      name: GeoVaLs/fraction_of_ice
+    #    maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/GTS.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/GTS.yaml
@@ -1,0 +1,96 @@
+  - obs space:
+      name: SnowDepthGTS
+      distribution:
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GTS_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_gts_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Composite
+      components:
+      # operator used to evaluate H(x)
+      - name: Identity
+      # operator used to evaluate background errors
+      - name: BackgroundErrorIdentity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+      maxvalue: 2000.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: MetaData/height
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: BlackList
+      where:
+      - variable:
+          name: MetaData/station_id
+        is_in: [71120,71397,71621,71727,71816]
+        size where true: 5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+    - filter: Met Office Buddy Check
+      filter variables:
+      - name: totalSnowDepth
+      rejection_threshold: 0.5
+      traced_boxes: # trace all observations
+        - min_latitude: -90
+          max_latitude:  90
+          min_longitude: -180
+          max_longitude:  180
+      search_radius: 150 # km
+      station_id_variable:
+        name: MetaData/station_id
+      num_zonal_bands: 24
+      sort_by_pressure: false
+      max_total_num_buddies: 15
+      max_num_buddies_from_single_band: 10
+      max_num_buddies_with_same_station_id: 5
+      use_legacy_buddy_collector: false
+      horizontal_correlation_scale: { "-90": 150, "90": 150 }
+      temporal_correlation_scale: PT6H
+      damping_factor_1: 1.0
+      damping_factor_2: 1.0
+      background_error_group: BkgError
+    - filter: Variable Assignment
+      assignments:
+      - name: GrossErrorProbability/totalSnowDepth
+        type: float
+        value: 0.02
+      - name: BkgError/totalSnowDepth_background_error
+        type: float
+        value: 30.0

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/IMS.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/IMS.yaml
@@ -1,0 +1,47 @@
+  - obs space:
+      name: SnowDepthIMS
+      distribution:
+         name: Halo
+         halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      observed variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: ioda.IMSscf.XXYYYYXXMMXXDD.XXTSTUB.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ims_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 1
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: GeoVaLs/vtype
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/SMAP.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/SMAP.yaml
@@ -1,0 +1,45 @@
+  - obs space:
+      name: SoilMoistureSMAP
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [soilMoistureVolumetric]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: SMAP_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_smap_XXYYYYXXMMXXDDTXXHH00.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+    obs filters:
+    - filter: Domain Check
+      where:
+      - variable: # land only
+          name: GeoVaLs/slmsk
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check
+      where:
+      - variable: # no snow
+          name: GeoVaLs/sheleg
+        maxvalue: 0.0
+    - filter: Domain Check
+      where:
+      - variable: # high-quality retrievals
+          name: PreQC/soilMoistureVolumetric
+        is_in: 0, 8
+    - filter: BlackList 
+      where:
+      - variable: # exclude certain IGBP vegetation types
+          name: GeoVaLs/vtype
+        absolute_tolerance: 1.0e-3
+        is_close_to_any_of: [1, 2, 3, 4, 13, 15, 17]

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/gfs-land-v17.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/gfs-land-v17.yaml
@@ -1,0 +1,16 @@
+field metadata:
+
+- long name: slmsk
+  interpolation type: nearest
+
+- long name: totalSnowDepth
+  io name: snodl
+  interpolation type: nearest
+
+- long name: vtype
+  interpolation type: nearest
+
+- long name: fraction_of_ice
+  io name: fice
+  interpolation type: nearest
+

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/gfs-soilMoisture.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/gfs-soilMoisture.yaml
@@ -1,0 +1,22 @@
+field metadata:
+
+- long name: slmsk
+  interpolation type: nearest
+
+- long name: vtype
+  interpolation type: nearest
+
+- long name: sheleg
+  interpolation type: nearest
+
+#- long name: tgxy
+#  io name: tgxy
+#  interpolation type: nearest
+
+- long name: stc
+  interpolation type: nearest
+  io file: surface
+
+- long name: soilMoistureVolumetric
+  io name: smc
+  io file: surface

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkf_snow.yaml_jedi_testcase
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkf_snow.yaml_jedi_testcase
@@ -1,0 +1,115 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk127.nc4
+  npx: 49
+  npy: 49
+  npz: 127
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+  time invariant state fields:
+    datetime: 2019-12-15T18:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: Data/inputs/gfs_land_c48/grid/
+    filename_orog: C48_oro_data.nc
+
+window begin: 2019-12-15T15:00:00Z
+window length: PT6H
+
+background:
+ date: &date 2019-12-15T18:00:00Z
+ members:
+   - datetime: 2019-12-15T18:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: Data/inputs/gfs_land_c48/mem001/
+     filename_sfcd: 20191215.180000.sfc_data.nc
+     filename_cplr: 20191215.180000.coupler.res
+   - datetime: 2019-12-15T18:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: Data/inputs/gfs_land_c48/mem002/
+     filename_sfcd: 20191215.180000.sfc_data.nc
+     filename_cplr: 20191215.180000.coupler.res
+
+observations:
+  observers:
+  - obs space:
+      name: Simulate
+      distribution:
+        name: InefficientDistribution
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: Data/obs/testinput_tier_1/ghcn_snwd_ioda_20191215.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: height@MetaData
+        minvalue: -999.0
+    - filter: Domain Check # land only
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+
+driver:
+  save posterior mean: true
+  save posterior mean increment: true
+  save posterior ensemble: false
+ # update obs config is set to true by default (which also implies halo distribution is used)
+ # need set to false here because halo distribution is NOT used for this run
+  update obs config with geometry info: false
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output:
+  filetype: auxgrid
+  gridtype: latlon
+  filename: Data/analysis/letkf/gfs_land/mem%{member}%/letkf.
+
+output increment:
+  filetype: auxgrid
+  gridtype: latlon
+  filename: Data/analysis/letkf/gfs_land/mem%{member}%/xainc.
+
+test:
+  reference filename: testoutput/letkf_snow.ref
+  test output filename: testoutput/letkf_snow.test.out

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_replay_GFSv17.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_replay_GFSv17.yaml
@@ -1,0 +1,166 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: gfs-land-v17.yaml
+
+  time invariant state fields:
+    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: XXTPATH
+    filename_orog: XXTSTUB.nc
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT6H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk,fice]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk,fice]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:
+  - obs space:
+      name: SnowDepthIMS
+      distribution:
+         name: Halo
+         halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      observed variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: ioda.IMSscf.XXYYYYXXMMXXDD.XXTSTUB.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ims_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 1
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: fraction_of_ice@GeoVaLs
+        maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject
+  - obs space:
+      name: Simulate
+      distribution: 
+        name: Halo
+        halo size: 250e3
+      simulated variables: [totalSnowDepth]
+      obsdatain:
+        engine:
+          type: H5File
+          obsfile: GHCN_XXYYYYXXMMXXDDXXHH.nc
+      obsdataout:
+        engine:
+          type: H5File
+          obsfile: output/DA/hofx/letkf_hofx_ghcn_XXYYYYXXMMXXDDXXHH.nc
+    obs operator:
+      name: Identity
+    obs error:
+      covariance model: diagonal
+    obs localizations:
+    - localization method: Horizontal SOAR
+      lengthscale: 250e3
+      soar horizontal decay: 0.000021
+      max nobs: 50
+    - localization method: Vertical Brasnett
+      vertical lengthscale: 700
+    obs filters:
+    - filter: Bounds Check # negative / missing snow
+      filter variables:
+      - name: totalSnowDepth
+      minvalue: 0.0
+    - filter: Domain Check # missing station elevation (-999.9)
+      where:
+      - variable:
+          name: height@MetaData
+        minvalue: -999.0
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: slmsk@GeoVaLs
+        minvalue: 0.5
+        maxvalue: 1.5
+    - filter: Domain Check # land only, no sea ice
+      where:
+      - variable:
+          name: fraction_of_ice@GeoVaLs
+        maxvalue: 0.0
+    - filter: RejectList  # no land-ice
+      where:
+      - variable:
+          name: vtype@GeoVaLs
+        minvalue: 14.5
+        maxvalue: 15.5
+    - filter: Background Check # gross error check
+      filter variables:
+      - name: totalSnowDepth
+      threshold: 6.25
+      action:
+        name: reject

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_smc.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_smc.yaml
@@ -1,0 +1,50 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: gfs-soilMoisture.yaml
+
+  time invariant state fields:
+    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: XXTPATH
+    filename_orog: XXTSTUB.nc
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT6H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [smc, vtype, sheleg, slmsk, stc]
+     datapath: ./
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/psl_develop/yaml_files/letkfoi_snow.yaml
@@ -1,0 +1,58 @@
+geometry:
+  fms initialization:
+    namelist filename: Data/fv3files/fmsmpp.nml
+    field table filename: Data/fv3files/field_table
+  akbk: Data/fv3files/akbk64.nc4
+  npx: XXREP
+  npy: XXREP
+  npz: 64
+  field metadata override: Data/fieldmetadata/gfs-land.yaml
+
+  time invariant fields:
+    state fields:
+      datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+      filetype: fms restart
+      skip coupler file: true
+      state variables: [orog_filt]
+      datapath: XXTPATH
+      filename_orog: XXTSTUB.nc
+    derived fields: [nominal_surface_pressure]
+
+window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+window length: PT24H
+
+background:
+ date: &date XXYYYY-XXMM-XXDDTXXHH:00:00Z
+ members:
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_pos/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+   - datetime: XXYYYY-XXMM-XXDDTXXHH:00:00Z
+     filetype: fms restart
+     state variables: [snwdph,vtype,slmsk]
+     datapath: mem_neg/
+     filename_sfcd: XXYYYYXXMMXXDD.XXHH0000.sfc_data.nc
+     filename_cplr: XXYYYYXXMMXXDD.XXHH0000.coupler.res
+
+driver:
+  save posterior mean: false
+  save posterior mean increment: true
+  save posterior ensemble: false
+  run as observer only: XXHOFX
+
+local ensemble DA:
+  solver: LETKF
+  inflation:
+    rtps: 0.0
+    rtpp: 0.0
+    mult: 1.0
+
+output increment:
+  filetype: fms restart
+  filename_sfcd: xainc.sfc_data.nc
+
+observations:
+  observers:

--- a/land_mods_hera
+++ b/land_mods_hera
@@ -1,5 +1,6 @@
 
 module purge
-module load  intel/2022.2
+module load intel/2022.2
 module load impi/2022.2.0
-module load  netcdf/4.7.0
+module load netcdf/4.7.0
+module load netcdf-hdf5parallel/4.7.4

--- a/land_mods_hera
+++ b/land_mods_hera
@@ -1,5 +1,5 @@
 
 module purge
-module load  intel/2020.2
-module load impi/2018.0.4
+module load  intel/2022.2
+module load impi/2022.2.0
 module load  netcdf/4.7.0


### PR DESCRIPTION
## Description

1. In the case of hera.internal baseline, 

- The latest JEDI internal version (https://github.com/JCSDA-internal/fv3-bundle.git@bd6acdc) is loaded.
- Added updated yaml files for the new JEDI version.
- 'srun' is used for now instead of using 'mpiexec'.

2. Changed to assimilate GHCN at 00 UTC. GHCN is time-stamped at 18:00. So, if assimilating at 00, DA needs to use the previous day's observation.

3. Updated GHCN observation dir: /scratch2/NCEPDEV/land/data/DA/

## Linked PR's and Issues:
https://github.com/ufs-community/land-DA_workflow/issues/21
https://github.com/ufs-community/land-DA_workflow/issues/22


### Testing (for CM's):
- RDHPCS
    - [X ] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP

- Tips for building
./build_all.sh