### PR TITLE
Add the artificial GHCN observations 

### DIFF
--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -137,7 +137,7 @@ do
   # GHCN are time-stamped at 18. If assimilating at 00, need to use previous day's obs, so that
   # obs are within DA window.
   elif [ ${OBS_TYPES[$ii]} == "GHCN" ]; then 
-     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYY}/ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
+     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYY}/fake_ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
   elif [ ${OBS_TYPES[$ii]} == "SYNTH" ]; then 
      obsfile=$OBSDIR/synthetic_noahmp/IODA.synthetic_gswp_obs.${YYYY}${MM}${DD}${HH}.nc
   else

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -136,8 +136,10 @@ do
      obsfile=$OBSDIR/snow_depth/GTS/data_proc/${YYYY}${MM}/adpsfc_snow_${YYYY}${MM}${DD}${HH}.nc4
   # GHCN are time-stamped at 18. If assimilating at 00, need to use previous day's obs, so that
   # obs are within DA window.
-  elif [ ${OBS_TYPES[$ii]} == "GHCN" ]; then 
-     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYY}/fake_ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
+  elif [ $atmos_forc == "era5" ] && [ ${OBS_TYPES[$ii]} == "GHCN" ]; then
+     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYY}/ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc
+  elif [ $atmos_forc == "gswp3" ] && [ ${OBS_TYPES[$ii]} == "GHCN" ]; then
+     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/v3/${YYYY}/fake_ghcn_snwd_ioda_${YYYP}${MP}${DP}.nc  
   elif [ ${OBS_TYPES[$ii]} == "SYNTH" ]; then 
      obsfile=$OBSDIR/synthetic_noahmp/IODA.synthetic_gswp_obs.${YYYY}${MM}${DD}${HH}.nc
   else

--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -97,12 +97,15 @@ do
 cp ${RSTRDIR}/${FILEDATE}.sfc_data.tile${tile}.nc  ${RSTRDIR}/${FILEDATE}.sfc_data_back.tile${tile}.nc
 done
 fi 
+
 #stage restarts for applying JEDI update (files will get directly updated)
 for tile in 1 2 3 4 5 6 
 do
   ln -fs ${RSTRDIR}/${FILEDATE}.sfc_data.tile${tile}.nc ${JEDIWORKDIR}/${FILEDATE}.sfc_data.tile${tile}.nc
 done
+
 cres_file=${JEDIWORKDIR}/${FILEDATE}.coupler.res
+
 if [[ -e  ${RSTRDIR}/${FILEDATE}.coupler.res ]]; then 
     ln -sf ${RSTRDIR}/${FILEDATE}.coupler.res $cres_file
 else #  if not present, need to create coupler.res for JEDI 


### PR DESCRIPTION
## Description

This just adds an artificial GHCN snow depth observation for the single-day cycle analysis for adding the GSWP3 forcing option. The GHCN observations will be extended in the near future.

## Linked PR's and Issues:
https://github.com/ufs-community/land-DA_workflow/issues/32

### Testing (for CM's):
- RDHPCS
    - [X ] Hera
    - [X ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
