### PR TITLE
Add EXECdir to meet nco standards

### DIFF
--- a/do_landDA.sh
+++ b/do_landDA.sh
@@ -37,6 +37,8 @@ LOGDIR=${OUTDIR}/DA/logs/
 # executables
 if [[ -e ${BUILDDIR}/bin/apply_incr.exe ]]; then #prefer cmake-built executables
   apply_incr_EXEC=${BUILDDIR}/bin/apply_incr.exe
+elif [[ -e ${EXECdir}/apply_incr.exe ]]; then # vertical dir structure in nco standards
+  apply_incr_EXEC=${EXECdir}/apply_incr.exe
 else
   apply_incr_EXEC=${CYCLEDIR}/DA_update/add_jedi_incr/exec/apply_incr
 fi


### PR DESCRIPTION
- According to the NCO standards, all executables should be located in the `EXECdir` directory.
- To make this work, EXECdir is added to the if-statement for the executable `apply_incr.exe`.